### PR TITLE
explicitly declare lazy_static dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ regex = "1.1.5"
 
 [dev-dependencies]
 glob = "0.3.0"
+lazy_static = "1"
 
 [features]
 simd-accel = []


### PR DESCRIPTION
`benches/bench.rs` uses lazy_static but Cargo.toml does not declare a dependency on it. This causes rustc to use its own internal private copy instead. Sometimes this causes unintuitive errors like Debian bug [942243](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=942243).

The underlying issue is rust-lang/rust#27812 but it can be avoided by explicitly declaring the dependency, which you are supposed to do anyways.