### PR TITLE
update cargo repo and homepage to new repo url

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ process of matching one or more glob patterns against a single candidate path
 simultaneously, and returning all of the globs that matched.
 """
 documentation = "https://docs.rs/globset"
-homepage = "https://github.com/BurntSushi/ripgrep/tree/master/globset"
-repository = "https://github.com/BurntSushi/ripgrep/tree/master/globset"
+homepage = "https://github.com/BurntSushi/globset"
+repository = "https://github.com/BurntSushi/globset"
 readme = "README.md"
 keywords = ["regex", "glob", "multiple", "set", "pattern"]
 license = "Unlicense/MIT"


### PR DESCRIPTION
The previous homepage/repo url doesn't exist anymore.  When following the links in https://crates.io or https://docs.rs they redirect to where `globset` used to exist, now a 404.