### PR TITLE
update to bstr 1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         include:
         - build: pinned
           os: ubuntu-18.04
-          rust: 1.28.0
+          rust: 1.60.0
     steps:
     - name: noop
       run: echo noop

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ repository = "https://github.com/BurntSushi/ripgrep/tree/master/globset"
 readme = "README.md"
 keywords = ["regex", "glob", "multiple", "set", "pattern"]
 license = "Unlicense/MIT"
+rust-version = "1.60"
 
 [lib]
 name = "globset"
@@ -20,7 +21,7 @@ bench = false
 
 [dependencies]
 aho-corasick = "0.7.3"
-bstr = { version = "0.2.0", default-features = false, features = ["std"] }
+bstr = { version = "1.0.0", default-features = false, features = ["std"] }
 fnv = "1.0.6"
 log = "0.4.5"
 regex = "1.1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "globset"
-version = "0.4.4"  #:version
+version = "0.5.0"  #:version
 authors = ["Andrew Gallant <jamslam@gmail.com>"]
 description = """
 Cross platform single glob and glob set matching. Glob set matching is the


### PR DESCRIPTION
This raises the MSRV to 1.60, which means that crates with lower MSRV requirements must stay on an older release.
However crates that depend on globset which have a newer MSRV can now update bstr (or dependencies that depend on bstr).
Without compiling two versions of bstr.

This problem occured in helix-editor/helix#3890.
Here we wanted to update gitoxide to 0.24, which depends on bstr 1.0 but chose to postpone because globset still depends on bstr 0.2.
