### PR TITLE
Add disclaimer to README referencing maintained crate location

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**UNDER CONSTRUCTION**
+**This repository is not maintained. [globset is maintained in ripgrep](https://github.com/BurntSushi/ripgrep/tree/master/crates/globset).**
 
 globset
 =======


### PR DESCRIPTION
👋 I noticed that there have been a couple mistaken pull requests here and unfortunately Google still lists this as the third hit (and first GitHub hit) for the [search "rust globset"](https://www.google.com/search?q=rust+globset). It'd be nice to include a simple disclaimer at the top of the README directing people to the real maintained crate.

